### PR TITLE
Fix button width issue on Contact Us page (#161)

### DIFF
--- a/src/components/PrimaryButton/index.js
+++ b/src/components/PrimaryButton/index.js
@@ -2,10 +2,10 @@ export default function PrimaryButton(props) {
   return (
     <button
       className="rounded-[40px] bg-primary-light text-white font-bold hover:bg-primary-dark py-2 px-6 w-fit"
-      style={{ maxHeight: "75px" }}
-      onClick={props.onClick}
+      style={ { maxHeight: "75px", maxWidth: "none", minWidth: "100%" } }
+      onClick={ props.onClick }
     >
-      <h3>{props.innerText}</h3>
+      <h3>{ props.innerText }</h3>
     </button>
   );
 }


### PR DESCRIPTION
Summary:

This pull request fixes an issue with the Contact Us page where the RSVP and Send buttons were not extending to the full width of their containing box. The issue was fixed by adding a style property to the buttons, setting the minWidth to 100% and maxWidth as none.

Changes:

Added style property to RSVP and Send buttons on PrimaryButton component. 

Why this is valuable:

This fix improves the user experience by making it easier for users to see and interact with the RSVP and Send buttons on the Contact Us page.