### PR TITLE
Fixes issue #164 updated classes of img and parent div

### DIFF
--- a/src/components/RsvpForm/index.jsx
+++ b/src/components/RsvpForm/index.jsx
@@ -9,8 +9,8 @@ export default function RsvpForm(){
     return (
         <div className={"text-center box-border pb-3"}>
             <div className={"relative block"}>
-                <div className={"block relative box-border w-fit overflow-hidden max-h-[410px]"}>
-                    <img className={"hidden sm:block relative"} src={require("../../assets/images/archivedImages/2018.png")} alt={"stock group photo"}/>
+                <div className={"block relative box-border object-cover overflow-hidden max-h-[410px]"}>
+                    <img className={"hidden sm:block relative w-full"} src={require("../../assets/images/archivedImages/2018.png")} alt={"stock group photo"}/>
                 </div>
                 <div className={"sm:absolute top-0 mx-auto block p-2 w-full"}>
                     <h1 className={"sm:text-white text-black"}>Want to Attend?</h1>


### PR DESCRIPTION
Updated Tailwind classes for the image and parent div so that bg image spans the width of all screens wider than the image. Change meets the DoD: The background image for Want to Attend? section fills the entire width of the screen on all screen sizes