### PR TITLE
Fix sub path navigation issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:1.22.1-alpine
 
 COPY build/ /usr/share/nginx/html
+COPY conf/default.conf /etc/nginx/conf.d/default.conf

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,0 +1,21 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    # Angular redirects
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
When loading a subpath (e.g. /about) it won't load since NGINX doesn't know where that path is. This sets NGINX to always send all requests directly through to the application.

Fixes #179 