### PR TITLE
Increase maximum height of an event list container. Fixes Mobile Events Calendar Cut Off on Saturday #214

### DIFF
--- a/src/components/Events/MobileDay/index.jsx
+++ b/src/components/Events/MobileDay/index.jsx
@@ -22,7 +22,7 @@ export default function MobileDay({ index, text, events }) {
         </svg>
       </div>
       {/* In order to make animations work, you can't use max-h-fit, it breaks them, awr max-h-[LARGE value].*/}
-      <div className="group group-focus:max-h-[500vh] max-h-0 px-4 overflow-hidden transition-all transform-gpu	ease-in-out duration-700">
+      <div className="group group-focus:max-h-[2000vh] max-h-0 px-4 overflow-hidden transition-all transform-gpu	ease-in-out duration-700">
         <div className="p-2 text-justify">{events}</div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #214

This pull request adresses the issue that some of the events are cut off from the screen. The issue was resolved by increasing maximum height of the container, since overflow in y-direction is hidden in order for the selector to work.